### PR TITLE
Fixed voltage output range in python lib

### DIFF
--- a/python/megaind/__init__.py
+++ b/python/megaind/__init__.py
@@ -152,7 +152,7 @@ def set0_10Out(stack, channel, value):
     checkChannel(channel)
     hwAdd = checkStack(stack)
     bus = smbus2.SMBus(BUS_NO)
-    if value < 0 or value > 10:
+    if value < -10 or value > 10:
         raise ValueError("Invalid value!")
     try:
         bus.write_word_data(hwAdd, U_0_10_OUT_VAL1_ADD + (2 * (channel - 1)), int(value * 1000))

--- a/python/setup.py
+++ b/python/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 setup(
     name='smmegaind',
     packages=find_packages(),
-    version='1.0.7',
+    version='1.0.8',
     license='MIT',
     description='Library to control Industrial Automation Card from Sequent Microsystems',
     long_description=long_description,


### PR DESCRIPTION
I saw you made the change in the c lib, but the range was still incorrect in the python implementation. I also went ahead and bumped the version number.